### PR TITLE
Fix the selector to the Ads Toast

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 (function() {
   'use strict';
   const checkAd = setInterval(() => {
-    const adBox = document.getElementById('tv-toasts');
+    const adBox = document.querySelector("[class^='toast-positioning-wrapper-']")
+
     if (adBox) {
       adBox.remove();
       console.log('ad removed.');

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "TradingView NoAds",
-    "version": "0.1",
+    "version": "0.2",
     "description": "Removes the annoying ads and the upgrade to pro message in TradingView",
     "browser_action": {
 	    "default_icon": {


### PR DESCRIPTION
A recent update in TradingView changed the selector of the Ads Toast making the messages in the free account appearing again.
This PR updates the selector to remove the toasts.