### PR TITLE
Fix Extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,11 @@
-(function() {
-  'use strict';
-  const checkAd = setInterval(() => {
-    const adBox = document.querySelector("[data-role^='toast-container']")
+(function () {
+  "use strict";
+  setInterval(() => {
+    const adBox = document.querySelector('[id="charting-ad"]');
 
     if (adBox) {
-      adBox.remove();
-      console.log('ad removed.');
-    } else {
-      console.log('no ad present.');
+      adBox.closest('[role="log"]')?.remove();
+      console.log("ad removed.");
     }
-  }, 5000);
+  }, 100);
 })();

--- a/manifest.json
+++ b/manifest.json
@@ -1,21 +1,22 @@
 {
-    "manifest_version": 2,
-    "name": "TradingView NoAds",
-    "version": "0.2",
-    "description": "Removes the annoying ads and the upgrade to pro message in TradingView",
-    "browser_action": {
-	    "default_icon": {
-        "128": "icon-128.png"
-      }
-    },
-    "content_scripts": [
-	    {
-	      "matches": [ "*://*.tradingview.com/*" ],
-      	"js": [ "index.js" ],
-	      "run_at": "document_start"
-    	}
-    ],
-    "icons": {
-	    "128": "icon-128.png"
+  "manifest_version": 3,
+  "name": "TradingView NoAds",
+  "version": "0.2",
+  "description": "Removes the annoying ads and the upgrade to pro message in TradingView",
+  "action": {
+    "default_icon": {
+      "128": "icon-128.png"
     }
+  },
+  "content_scripts": [
+    {
+      "matches": ["*://*.tradingview.com/*"],
+      "js": ["index.js"],
+      "run_at": "document_start"
+    }
+  ],
+  "icons": {
+    "128": "icon-128.png"
+  },
+  "permissions": []
 }


### PR DESCRIPTION
- The manifest was in a deprecated version so wouldn't run on Chrome. This PR updates it to a more recent functioning version
- The ads weren't being blocked, because the HTML had changed for the ads the query selector was no longer picking them up, this PR fixes it so it works for the latest ads
- The script was only running every 5 seconds, meaning it took on average 2.5 seconds to remove the ad. This script changes it to run every 0.1 seconds instead to remove them in on average 0.05 seconds.